### PR TITLE
Add event feature (#4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/react-datepicker": "^4.4.2",
     "@types/react-dom": "^18.0.6",
     "@types/styled-components": "^5.1.26",
+    "@types/uuid": "^8.3.4",
     "formik": "^2.2.9",
     "react": "^18.2.0",
     "react-datepicker": "^4.8.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { LanguageContext } from './store/contexts/LanguageContextProvider'
 import { Routes, Route } from "react-router-dom"
 import Home from './pages/Home'
 import DocumentTitleProvider from './DocumentTitleProvider'
+import AddEvent from './pages/AddEvent'
 
 const App = () => {
   const langContext = useContext(LanguageContext)
@@ -21,7 +22,7 @@ const App = () => {
         <Layout>
         <Routes>
           <Route element={<Home />} path="/" />
-          <Route element={<Home />} path="/event/:id" />
+          <Route element={<AddEvent />} path="/add-event" />
         </Routes>
         </Layout>
       </DocumentTitleProvider>

--- a/src/components/FormikControl/FormikControl.tsx
+++ b/src/components/FormikControl/FormikControl.tsx
@@ -1,15 +1,10 @@
 import React from 'react'
 import CheckboxInput from '../atomic-ui/molecules/FormikInputs/CheckboxInput'
+import DatePickerInput from '../atomic-ui/molecules/FormikInputs/DatePickerInput'
+import FileInput from '../atomic-ui/molecules/FormikInputs/FileInput'
 import RadioInput from '../atomic-ui/molecules/FormikInputs/RadioInput'
-// import { IKeyValueStringObject } from '../../types'
 import SelectInput from '../atomic-ui/molecules/FormikInputs/SelectInput'
 import TextInput from '../atomic-ui/molecules/FormikInputs/TextInput'
-// import ChakraInput from './ChakraInput'
-// import CheckboxGroup from './CheckboxGroup'
-// import DatePicker from './DatePicker'
-// import RadioButtons from './RadioButtons'
-// import Select from './Select'
-// import Textarea from './Textarea'
 
 interface IFormikControl {
   control: string
@@ -30,8 +25,10 @@ const FormikControl: React.FC<IFormikControl> = ({
       return <RadioInput {...rest} />
     case 'checkbox':
       return <CheckboxInput {...rest} />
-    // case 'date':
-    //   return <DatePicker {...rest} />
+    case 'date':
+      return <DatePickerInput {...rest} />
+    case 'file':
+        return <FileInput {...rest} />
     default:
       return null
   }

--- a/src/components/atomic-ui/atoms/PreviewImage/PreviewImage.tsx
+++ b/src/components/atomic-ui/atoms/PreviewImage/PreviewImage.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react"
+import { FormattedMessage } from "react-intl"
+import { MAX_FILE_SIZE, SUPPORTED_PHOTO_FORMAT } from "../../../../constants/variables"
+import Text from "../Text"
+
+interface IPreviewImageProps {
+    file: Blob
+}
+
+const PreviewImage: React.FC<IPreviewImageProps> = ({ file }) => {
+    const [preview, setPreview] = useState<string | undefined>()
+    const fileReader = new FileReader()
+
+    fileReader.readAsDataURL(file)
+    fileReader.onload = () => {
+        const photo: string | undefined = fileReader.result as string | undefined
+        setPreview(photo)
+    }
+
+    const formatErrorMessage = !SUPPORTED_PHOTO_FORMAT.includes(file?.type) &&
+      <FormattedMessage id="PreviewImage.formatErrorMessage" />
+    const sizeErrorMessage = !SUPPORTED_PHOTO_FORMAT.includes(file?.type) &&
+      <FormattedMessage id="PreviewImage.sizeErrorMessage" />
+  return (
+    <>
+      {file && SUPPORTED_PHOTO_FORMAT.includes(file?.type) || file?.size <= MAX_FILE_SIZE ? (
+        <div>{preview ? (<img alt="event photo" height="200" src={preview} width="200" />) : "Loading..."}</div>
+      ) : (
+        <>
+          <Text isErrorText>{formatErrorMessage}</Text>
+          <Text isErrorText>{sizeErrorMessage}</Text>
+        </>
+      )}
+    </>
+  )
+}
+
+export default PreviewImage

--- a/src/components/atomic-ui/atoms/PreviewImage/index.tsx
+++ b/src/components/atomic-ui/atoms/PreviewImage/index.tsx
@@ -1,0 +1,3 @@
+import PreviewImage from "./PreviewImage"
+
+export default PreviewImage

--- a/src/components/atomic-ui/molecules/FormikInputs/CheckboxInput/CheckboxInput.tsx
+++ b/src/components/atomic-ui/molecules/FormikInputs/CheckboxInput/CheckboxInput.tsx
@@ -16,7 +16,7 @@ const CheckboxInput: React.FC<ICheckboxInput> = ({
 }) => {
   const restProps = {"aria-label": label ? `${name} field`: undefined, ...rest}
   return (
-    <div className='form-control'>
+    <div className='form-group'>
       {label && <label className="checkboxLabelInputDescritpion" htmlFor={id}>{label}</label>}
       <Field aria-describedby={id && `${id}Error`} id={id} name={name} {...restProps}>
         {({ field }: FieldProps) => {
@@ -25,6 +25,7 @@ const CheckboxInput: React.FC<ICheckboxInput> = ({
               <React.Fragment key={option.key}>
                 <input
                   checked={field?.value.includes(option.value)}
+                  className={'form-control'}
                   id={option.value}
                   type='checkbox'
                   {...field}

--- a/src/components/atomic-ui/molecules/FormikInputs/DatePickerInput/DatePickerInput.tsx
+++ b/src/components/atomic-ui/molecules/FormikInputs/DatePickerInput/DatePickerInput.tsx
@@ -5,10 +5,10 @@ import 'react-datepicker/dist/react-datepicker.css'
 import { IbasicInputProps } from '../../../../../types'
 import Text from '../../../atoms/Text'
 
-const DatePicker: React.FC<IbasicInputProps> =  ({ id, label, name, ...rest }) => {
+const DatePickerInput: React.FC<IbasicInputProps> =  ({ id, label, name, ...rest }) => {
   const restProps = {"aria-label": !label ? `${name} field`: undefined, ...rest}
   return (
-    <div className='form-control'>
+    <div className='form-group'>
       {label && <label htmlFor={id}>{label}</label>}
       <Field aria-describedby={id && `${id}Error`} id={id} name={name} {...restProps}>
         {({ form, field }: FieldProps) => {
@@ -16,7 +16,7 @@ const DatePicker: React.FC<IbasicInputProps> =  ({ id, label, name, ...rest }) =
           const { value } = field
           return (
             <DateView
-              className="date-input"
+              className="date-input form-control"
               id={name}
               selected={value}
               {...field}
@@ -31,4 +31,4 @@ const DatePicker: React.FC<IbasicInputProps> =  ({ id, label, name, ...rest }) =
   )
 }
 
-export default DatePicker
+export default DatePickerInput

--- a/src/components/atomic-ui/molecules/FormikInputs/DatePickerInput/index.tsx
+++ b/src/components/atomic-ui/molecules/FormikInputs/DatePickerInput/index.tsx
@@ -1,3 +1,4 @@
-import DatePicker from "./DatePickerInput"
+import DatePickerInput from "./DatePickerInput"
 
-export default DatePicker
+export default DatePickerInput
+

--- a/src/components/atomic-ui/molecules/FormikInputs/FileInput/FileInput.tsx
+++ b/src/components/atomic-ui/molecules/FormikInputs/FileInput/FileInput.tsx
@@ -1,4 +1,4 @@
-import { ErrorMessage, Field, FieldProps } from "formik"
+import { ErrorMessage } from "formik"
 import React from "react"
 import { IbasicInputProps } from "../../../../../types"
 import Text from "../../../atoms/Text"
@@ -6,26 +6,16 @@ import Text from "../../../atoms/Text"
 const FileInput: React.FC<IbasicInputProps> =  ({ id, label, name, ...rest }) => {
     const restProps = {"aria-label": !label ? `${name} field`: undefined, ...rest}
     return (
-      <div className='form-control'>
+      <div className='form-group'>
         {label && <label htmlFor={id}>{label}</label>}
-        <Field aria-describedby={id && `${id}Error`} id={id} name={name} {...restProps}>
-          {({ form, field }: FieldProps) => {
-            const {setFieldValue} = form
-            // const { value } = field
-            return (
               <input
-                className="date-input"
-                id={name}
+                aria-describedby={id && `${id}Error`}
+                className="date-input form-control"
+                id={id}
+                name={name}
                 type="file"
-                {...field}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    e.target.files instanceof FileList && setFieldValue(name, e.target.files[0])
-                }}
-                {...rest}
+                {...restProps}
               />
-            )
-          }}
-        </Field>
         <ErrorMessage name={name} render={msg => <Text id={id && `${id}-error`} isErrorText>{msg}</Text>} />
         </div>
     )

--- a/src/components/atomic-ui/molecules/FormikInputs/RadioInput/RadioInput.tsx
+++ b/src/components/atomic-ui/molecules/FormikInputs/RadioInput/RadioInput.tsx
@@ -12,7 +12,7 @@ const RadioInput: React.FC<ICheckboxInput> = ({
 }) => {
   const restProps = {"aria-label": label ? `${name} field`: undefined, ...rest}
   return (
-    <div className="form-control">
+    <div className="form-group">
       {label && <label className="radioLabelInputDescritpion">{label}</label>}
       <Field aria-describedby={id && `${id}Error`} id={id} name={name} {...restProps}>
         {({ field }: FieldProps) => {
@@ -21,7 +21,7 @@ const RadioInput: React.FC<ICheckboxInput> = ({
               <React.Fragment key={option.key}>
                 <input
                   checked={field?.value === option.value}
-                  className="radio-input"
+                  className="radio-input form-control"
                   id={option.value}
                   type="radio"
                   {...field}

--- a/src/components/atomic-ui/molecules/FormikInputs/SelectInput/SelectInput.tsx
+++ b/src/components/atomic-ui/molecules/FormikInputs/SelectInput/SelectInput.tsx
@@ -1,4 +1,5 @@
 import { ErrorMessage, Field } from 'formik'
+import React from 'react'
 import { IKeyValueStringObject } from '../../../../../types'
 import Text from '../../../atoms/Text'
 
@@ -19,15 +20,15 @@ const SelectInput: React.FC<ISelectInput> = ({
 }) => {
   const restProps = {"aria-label": label ? `${name} field`: undefined, ...rest}
   return (
-    <div className="form-control">
+    <div className="form-group">
+      <>
       {label && <label htmlFor={id}>{label}</label>}
-      <label htmlFor={'id'}>{label}</label>
       <Field
-        aria-describedBy={id && `${id}Error`}
+        aria-describedby={id && `${id}Error`}
         as="select"
-        className="select-input"
+        className="select-input form-control"
         id={'id'}
-        name={'name'}
+        name={name}
         {...restProps}
       >
         {options?.map((option) =>  (
@@ -38,6 +39,7 @@ const SelectInput: React.FC<ISelectInput> = ({
         )}
       </Field>
       <ErrorMessage name={name} render={msg => <Text id={id && `${id}-error`} isErrorText>{msg}</Text>} />
+      </>
     </div>
   )
 }

--- a/src/components/atomic-ui/molecules/FormikInputs/TextInput/TextInput.tsx
+++ b/src/components/atomic-ui/molecules/FormikInputs/TextInput/TextInput.tsx
@@ -12,12 +12,12 @@ interface ITextInput {
 const TextInput: React.FC<ITextInput> = ({ id, label, name, control="text", ...rest }) => {
   const restProps = {"aria-label": label ? `${name} field`: undefined, ...rest}
   return (
-    <div className="form-control">
+    <div className="form-group">
       {label && <label htmlFor={id}>{label}</label>}
       <Field
-        aria-describedBy={id && `${id}Error`}
+        aria-describedby={id && `${id}Error`}
         as={control === "textarea" && control}
-        className="text-input"
+        className="text-input form-control"
         id={id}
         name={name}
         {...restProps}

--- a/src/components/atomic-ui/molecules/LocaleSwitcher/LocaleSwitcher.style.ts
+++ b/src/components/atomic-ui/molecules/LocaleSwitcher/LocaleSwitcher.style.ts
@@ -1,0 +1,17 @@
+import styled from 'styled-components'
+import rem from '../../../../utils/rem'
+
+const LocaleSwitcherStyle = styled.div({
+    '.labelStyle': {
+        marginRight: rem(5)
+     },
+   '.select': {
+      appearance: "none",
+      border: "none",
+   },
+   display: 'flex',
+   justifyContent: "end",
+   padding: rem(10)
+})
+
+export default LocaleSwitcherStyle

--- a/src/components/atomic-ui/molecules/LocaleSwitcher/LocaleSwitcher.tsx
+++ b/src/components/atomic-ui/molecules/LocaleSwitcher/LocaleSwitcher.tsx
@@ -1,6 +1,8 @@
 import React, { useContext } from "react"
+import { FormattedMessage } from "react-intl"
 import { localeDropdownOptions } from "../../../../constants/variables"
 import { LanguageContext } from "../../../../store/contexts/LanguageContextProvider"
+import LocaleSwitcherStyle from "./LocaleSwitcher.style"
 
 
 const LocaleSwitcher = () => {
@@ -12,8 +14,11 @@ const LocaleSwitcher = () => {
   }
 
   return (
-    <div>
-      <select onChange={changeHandler}>
+    <LocaleSwitcherStyle>
+      <label className="labelStyle" htmlFor="localeSwitcherSelect">
+        <FormattedMessage id="LocaleSwitcher.changeLanguage"/>:
+      </label>
+      <select className="select" id="localeSwitcherSelect" onChange={changeHandler}>
         <option value={langContext?.lang ?? ""}>{langContext?.lang?.toUpperCase() || ""}</option>
         {localeDropdownOptions?.filter(option => option.value !== langContext?.lang)?.map((option) =>  (
             <option key={option?.value} value={option?.value}>
@@ -22,7 +27,7 @@ const LocaleSwitcher = () => {
           )
         )}
       </select>
-    </div>
+    </LocaleSwitcherStyle>
   )
 }
 

--- a/src/constants/countriesAndStatesData.ts
+++ b/src/constants/countriesAndStatesData.ts
@@ -1,0 +1,39 @@
+import { TCountry } from "../types"
+import firstCharToUpperCase from "../utils/firstCharToUpperCase"
+
+const countryAndStates = {
+    nigeria: [
+        "lagos",
+        "abuja",
+        "kaduna"
+    ],
+    usa: [
+        "chicago",
+        "carlifornia"
+    ]
+}
+
+export const deriveCountriesDropdownKeyAndValue = () => {
+    const data = [{key: "-- Select Country --", value: ""}]
+    for (const key in countryAndStates) {
+        if (Object.prototype.hasOwnProperty.call(countryAndStates, key)) {
+            data.push({ "key": firstCharToUpperCase(key), value: key})
+        }
+    }
+    return data
+}
+
+export const getStatesDropdownDataFromCountry = (country: TCountry) => {
+    const statesDropDown = [{key: "-- Select State --", value: ""}]
+
+    const statesData = countryAndStates[country]
+    for (const key in statesData) {
+        if (Object.prototype.hasOwnProperty.call(statesData, key)) {
+            const state =statesData[key]
+            statesDropDown.push({ "key": firstCharToUpperCase(state), value: state})
+        }
+    }
+    return statesDropDown || []
+}
+
+export default countryAndStates

--- a/src/constants/variables.ts
+++ b/src/constants/variables.ts
@@ -1,6 +1,10 @@
+import rem from "../utils/rem"
+
+export const defaultFontSize = 14
+
 export const errorStyle = {
     color: "red",
-    fontSize: "13px"
+    fontSize: rem(13)
 }
 
 export const localeDropdownOptions = [
@@ -8,6 +12,4 @@ export const localeDropdownOptions = [
     { key: 'FR', value: 'fr' },
 ]
 
-export const defaultFontSize = 14
-
-export const appName = "JamApp"
+export const appName = "JamEvent"

--- a/src/constants/variables.ts
+++ b/src/constants/variables.ts
@@ -13,3 +13,7 @@ export const localeDropdownOptions = [
 ]
 
 export const appName = "JamEvent"
+
+export const SUPPORTED_PHOTO_FORMAT = ["image/jpg", "image/jpeg", "image/png"]
+
+export const MAX_FILE_SIZE = 1024 * 1024

--- a/src/customHooks/useDocumentTitle.tsx
+++ b/src/customHooks/useDocumentTitle.tsx
@@ -1,4 +1,4 @@
-import {useEffect} from 'react'
+import { useEffect } from 'react'
 import { appName } from '../constants/variables'
 import { useLocation } from "react-router-dom"
 import getStringFromLongText from '../utils/getStringFromLongText'
@@ -9,7 +9,7 @@ function useDocumentTitle() {
 
   useEffect(() => {
     document.title = `${appName} - ${currentPage}`
-  }, [])
+  }, [currentPage])
 }
 
 export default useDocumentTitle

--- a/src/globalStyles/StyledForm.style.ts
+++ b/src/globalStyles/StyledForm.style.ts
@@ -1,0 +1,21 @@
+import styled from 'styled-components'
+import rem from '../utils/rem'
+
+export const StyledForm  = styled.div({
+  ".legend": {
+    textAlign: "center"
+  },
+  "form-group": {
+    ".form-control": {
+        backgroundClip: "padding-box",
+        backgroundColor: "#fff",
+        backgroundImage: "none",
+        border: "1px solid #ced4da",
+        color: "#495057",
+        display: "block",
+        fontSize: rem(14),
+        marginBottom: rem(10),
+    },
+    marginBottom: rem(10),
+  }
+})

--- a/src/locale/langs/en.json
+++ b/src/locale/langs/en.json
@@ -1,3 +1,6 @@
 {
-  "Global.hello": "Hello"
+  "Global.hello": "Hello",
+  "Home.pageHeaderText": "Imagine if Snapchat had event",
+  "Home.addEventButtonText": "Create my event",
+  "LocaleSwitcher.changeLanguage": "Change Language"
 }

--- a/src/locale/langs/en.json
+++ b/src/locale/langs/en.json
@@ -1,6 +1,9 @@
 {
   "Global.hello": "Hello",
+  "LocaleSwitcher.changeLanguage": "Change Language",
+  "PreviewImage.sizeErrorMessage": "File size should not be greater than 1mb -- in french",
+  "PreviewImage.formatErrorMessage": "File format not supported -- in french",
   "Home.pageHeaderText": "Imagine if Snapchat had event",
   "Home.addEventButtonText": "Create my event",
-  "LocaleSwitcher.changeLanguage": "Change Language"
+  "AddEvent.formTitle": "Create new event"
 }

--- a/src/locale/langs/fr.json
+++ b/src/locale/langs/fr.json
@@ -1,3 +1,6 @@
 {
-  "Global.hello": "Bonjour"
+  "Global.hello": "Bonjour",
+  "Home.pageHeaderText": "Imagine if Snapchat had event",
+  "Home.addEventButtonText": "Create my event",
+  "LocaleSwitcher.changeLanguage": "Change Language"
 }

--- a/src/locale/langs/fr.json
+++ b/src/locale/langs/fr.json
@@ -1,6 +1,9 @@
 {
   "Global.hello": "Bonjour",
+  "LocaleSwitcher.changeLanguage": "Change Language",
+  "PreviewImage.sizeErrorMessage": "File size should not be greater than 1mb -- in french",
+  "PreviewImage.formatErrorMessage": "File format not supported -- in french",
   "Home.pageHeaderText": "Imagine if Snapchat had event",
   "Home.addEventButtonText": "Create my event",
-  "LocaleSwitcher.changeLanguage": "Change Language"
+  "AddEvent.formTitle": "Create new event -- in french"
 }

--- a/src/pages/AddEvent/AddEvent.formdata.ts
+++ b/src/pages/AddEvent/AddEvent.formdata.ts
@@ -1,0 +1,38 @@
+import * as Yup from 'yup'
+import { MAX_FILE_SIZE, SUPPORTED_PHOTO_FORMAT } from '../../constants/variables'
+
+export const eventDataValidationSchema = Yup.object({
+    endDate: Yup.date().required('Required').nullable(),
+    eventCity: Yup.string().when(['eventCountry', 'eventState'], {
+        is: true,
+        then: Yup.string().required('Required'),
+    }),
+    eventCountry: Yup.string().required('Required'),
+    eventName: Yup.string().required('Required'),
+    eventPhoto: Yup.mixed().nullable().required('Event Photo Required').test(
+        "fileSize",
+        "Uploaded file is too big.",
+        (value) => !value || (value && value?.size <= MAX_FILE_SIZE)
+    ).test(
+        "fileType",
+        "Uploaded file is of unsupported format.",
+        (value) => value && (value && SUPPORTED_PHOTO_FORMAT.includes(value?.type))
+    ),
+    eventState: Yup.string().when('eventCountry', {
+        is: true,
+        then: Yup.string().required('Required'),
+    }),
+    hostName: Yup.string().required('Required'),
+    startDate: Yup.date().required('Required').nullable(),
+})
+
+export const eventDataInitialValues = {
+    endDate: null,
+    eventCity: "",
+    eventCountry: "",
+    eventName: "",
+    eventPhoto: null,
+    eventState: "",
+    hostName: "",
+    startDate: null,
+}

--- a/src/pages/AddEvent/AddEvent.tsx
+++ b/src/pages/AddEvent/AddEvent.tsx
@@ -1,0 +1,8 @@
+const AddEvent = () => {
+    return (
+      <div>AddEvent</div>
+    )
+  }
+  
+  export default AddEvent
+  

--- a/src/pages/AddEvent/AddEvent.tsx
+++ b/src/pages/AddEvent/AddEvent.tsx
@@ -1,8 +1,133 @@
+import { Form, Formik } from "formik"
+import { useState } from "react"
+import { FormattedMessage } from "react-intl"
+import PreviewImage from "../../components/atomic-ui/atoms/PreviewImage"
+import Text from "../../components/atomic-ui/atoms/Text"
+import FormikControl from "../../components/FormikControl"
+import { deriveCountriesDropdownKeyAndValue, getStatesDropdownDataFromCountry } from "../../constants/countriesAndStatesData"
+import { StyledForm } from "../../globalStyles/StyledForm.style"
+import { TCountry } from "../../types"
+import { eventDataInitialValues, eventDataValidationSchema } from "./AddEvent.formdata"
+import { v4 as uuidv4 } from 'uuid'
+
+interface IEventDataInitialValues {
+    endDate: string | null,
+    eventCity: string,
+    eventCountry: string,
+    eventName: string,
+    eventState: string,
+    hostName: string,
+    startDate: string | null,
+}
+
 const AddEvent = () => {
-    return (
-      <div>AddEvent</div>
-    )
-  }
-  
-  export default AddEvent
-  
+    const [statesDropdown, setStatesDropdown] = useState<{key: string, value: string}[] | []>([])
+
+    const countriesDropdownData = deriveCountriesDropdownKeyAndValue()
+    const submitHandler = (values: IEventDataInitialValues) => {
+        const valuesWithId = {id: uuidv4(), ...values}
+        // eslint-disable-next-line no-console
+        console.log(valuesWithId)
+    }
+    
+  return (
+    <div>
+    <Formik
+      initialValues={eventDataInitialValues}
+      validationSchema={eventDataValidationSchema}
+      // eslint-disable-next-line react/jsx-sort-props
+      onSubmit={submitHandler}
+    >
+      {(formik) => {
+        return (
+          <StyledForm>
+            <Form>
+            <fieldset className="AddEvent-formFieldSet">
+                <legend className="AddEvent-formLegend legend">
+                <Text as={"h2"}>
+                    <FormattedMessage id="AddEvent.formTitle" />
+                </Text>
+                </legend>
+            
+              <FormikControl
+                control="input"
+                label="Event Name"
+                name="eventName"
+                type="text"
+              />
+              <FormikControl
+                control="input"
+                label="Host Name"
+                name="hostName"
+                type="text"
+              />
+
+              <FormikControl
+                control="date"
+                label="Start Date"
+                name="startDate"
+              />
+
+              <FormikControl
+                control="date"
+                label="End Date"
+                name="endDate"
+              />
+
+              <FormikControl
+                control="select"
+                label="Select Country"
+                name="eventCountry"
+                onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+                    const val = `${e.target.value}`
+                    if (val) {
+                        const country: TCountry = val as TCountry
+                        setStatesDropdown(getStatesDropdownDataFromCountry(country))
+                    } else {
+                        setStatesDropdown([])
+                    }
+                    formik.setFieldValue("eventCountry", e.target.value)
+                }}
+                options={countriesDropdownData}
+              />
+
+              <FormikControl
+                control="select"
+                label="Select State"
+                name="eventState"
+                options={statesDropdown}
+              />
+
+              <FormikControl
+                control="input"
+                label="Select City"
+                name="eventCity"
+                type={"text"}
+              />
+
+              {formik.values.eventPhoto && <PreviewImage file={formik.values.eventPhoto} />}
+
+              <FormikControl
+                control="file"
+                id={"file"}
+                label="Upload Event Photo"
+                name="eventPhoto"
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  e.target.files instanceof FileList && formik.setFieldValue("eventPhoto", e.target.files[0])
+                }}
+              />
+
+              <button disabled={!formik.isValid} type="submit">
+                Submit
+              </button>
+            </fieldset>
+            </Form>
+          </StyledForm>
+          )
+        }}
+      </Formik>
+    </div>
+  )
+}
+
+export default AddEvent

--- a/src/pages/AddEvent/index.tsx
+++ b/src/pages/AddEvent/index.tsx
@@ -1,0 +1,3 @@
+import AddEvent from "./AddEvent"
+
+export default AddEvent

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,11 +1,22 @@
 import Text from "../../components/atomic-ui/atoms/Text"
 import { FormattedMessage } from 'react-intl'
+import { useNavigate } from "react-router-dom"
 
 const Home = () => {
+  const navigate = useNavigate()
+  const routeToCreatePage = () => {
+    navigate("/add-event")
+  }
   return (
-    <Text as={"h1"} id="app-text" style={{color: "red"}}>
-          <FormattedMessage id="Global.hello" />
+    <section>
+      <div>
+        <Text as={"h1"} id="app-text" style={{color: "red"}}>
+          <FormattedMessage id="Home.pageHeaderText" />
         </Text>
+      </div>
+      <div>img</div>
+      <button onClick={routeToCreatePage} type="button"><FormattedMessage id="Home.addEventButtonText" /></button>
+    </section>
   )
 }
 

--- a/src/types/country.ts
+++ b/src/types/country.ts
@@ -1,0 +1,1 @@
+export type TCountry = "nigeria" | "usa"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,3 +17,4 @@ export type {
   IbasicInputProps
 } from './global'
 export type { TVariants } from './variants'
+export type { TCountry } from './country'

--- a/src/utils/getStringFromLongText.ts
+++ b/src/utils/getStringFromLongText.ts
@@ -17,8 +17,6 @@ const getStringFromLongText = (
     textToFind = textArray[index]
   }
 
-  console.log(textToFind)
-
   textToFind = textToFind || fallbackText
 
   return firstCharToUpperCase(textToFind)

--- a/src/utils/getStringFromLongText.ts
+++ b/src/utils/getStringFromLongText.ts
@@ -17,6 +17,8 @@ const getStringFromLongText = (
     textToFind = textArray[index]
   }
 
+  console.log(textToFind)
+
   textToFind = textToFind || fallbackText
 
   return firstCharToUpperCase(textToFind)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2447,6 +2447,11 @@
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.2.tgz#fc25ad9943bcac11cceb8168db4f275e0e72e756"
   integrity sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==
 
+"@types/uuid@^8.3.4":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
+  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
+
 "@types/ws@^8.5.1":
   version "8.5.3"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.3.tgz#7d25a1ffbecd3c4f2d35068d0b283c037003274d"


### PR DESCRIPTION
- closes #4 

## This PR does the following

- improve on the `useDocumentTitle` hook to update page title on initial render
- Add "create event" button to home page
- Make button navigatable to "add event" page
- Created the "add event" page
- Add event form with necessary fields, validation, accessibility and submission data

 
## Test Plan

- [x] confirm that on page change the page title gets updated accordingly
- [x] confirm that "create event" button on home page leads to "add-event" page
- [x] confirm that on add event page, The add event form is visible with all necessary fields (Event name, Host name, Start and End time/date, Location and Event photo)
- [x] confirm that fields works and all validation works too..
- [x] confirm that all form data can be collected successfully